### PR TITLE
新增配置参数mq_max_message_length(默认20480); 支持redis扩展的set/setex命令 (#351)

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -147,6 +147,7 @@ if test "$PHP_SKYWALKING" != "no"; then
       src/sky_core_span_log.cc \
       src/sky_execute.cc \
       src/sky_grpc.cc \
+      src/sky_log.cc \
       src/sky_module.cc \
       src/sky_plugin_mysqli.cc \
       src/sky_pdo.cc \

--- a/e2e/tests/redis.php
+++ b/e2e/tests/redis.php
@@ -16,5 +16,35 @@ function testRedis() {
     $redis->incr($key);
     $redis->setnx($key, "test");
     $redis->strlen($key);
+    $redis->set($key, "test");
+    $redis->set($key, "test", 100);
+    $redis->set($key, "test", ["nx", "ex" => 200]);
+    $redis->setex($key, 300, "test");
 
+    // multiple keys
+    $redis->mget([$key .'_1', $key . '_2', $key . '_3']);
+    $redis->getMultiple([$key .'_1', $key . '_2', $key . '_3']);
+
+    // uncertain keys
+    $redis->eval('return {1,2,3};');
+    $redis->del($key);
+    $redis->del($key, $key . '_1');
+    $redis->del([$key, $key . '_1', $key . '_2']);
+    $redis->delete($key);
+    $redis->unlink($key);
+    $redis->exists($key);
+
+    // empty commands
+    $redis->ping();
+    $redis->pipeline();
+    $redis->set($key, '1');
+    $redis->set($key . '_1', '2');
+    $redis->set($key . '_2', '3');
+    $redis->exec();
+
+    // expire
+    $redis->expire($key, 3600);
+    $redis->expireAt($key, time() + 3600);
+    $redis->pExpireAt($key, time() + 3600);
+    $redis->setTimeout($key, 3600);
 }

--- a/php_skywalking.h
+++ b/php_skywalking.h
@@ -111,6 +111,9 @@ ZEND_BEGIN_MODULE_GLOBALS(skywalking)
 
     // php error log
     zend_bool error_handler_enable;
+
+    // message queue
+    int mq_max_message_length;
 ZEND_END_MODULE_GLOBALS(skywalking)
 
 extern ZEND_DECLARE_MODULE_GLOBALS(skywalking);

--- a/skywalking.cc
+++ b/skywalking.cc
@@ -33,22 +33,23 @@ ZEND_DECLARE_MODULE_GLOBALS(skywalking)
 
 struct service_info *s_info = nullptr;
 
-
 PHP_INI_BEGIN()
     STD_PHP_INI_BOOLEAN("skywalking.enable", "0", PHP_INI_ALL, OnUpdateBool, enable, zend_skywalking_globals, skywalking_globals)
 	STD_PHP_INI_ENTRY("skywalking.version", "8", PHP_INI_ALL, OnUpdateLong, version, zend_skywalking_globals, skywalking_globals)
 	STD_PHP_INI_ENTRY("skywalking.app_code", "hello_skywalking", PHP_INI_ALL, OnUpdateString, app_code, zend_skywalking_globals, skywalking_globals)
 	STD_PHP_INI_ENTRY("skywalking.authentication", "", PHP_INI_ALL, OnUpdateString, authentication, zend_skywalking_globals, skywalking_globals)
 	STD_PHP_INI_ENTRY("skywalking.grpc", "127.0.0.1:11800", PHP_INI_ALL, OnUpdateString, grpc, zend_skywalking_globals, skywalking_globals)
-	STD_PHP_INI_ENTRY("skywalking.grpc_tls_enable", "0", PHP_INI_ALL, OnUpdateBool, grpc_tls_enable, zend_skywalking_globals, skywalking_globals)
+	STD_PHP_INI_BOOLEAN("skywalking.grpc_tls_enable", "0", PHP_INI_ALL, OnUpdateBool, grpc_tls_enable, zend_skywalking_globals, skywalking_globals)
 	STD_PHP_INI_ENTRY("skywalking.grpc_tls_pem_root_certs", "", PHP_INI_ALL, OnUpdateString, grpc_tls_pem_root_certs, zend_skywalking_globals, skywalking_globals)
 	STD_PHP_INI_ENTRY("skywalking.grpc_tls_pem_private_key", "", PHP_INI_ALL, OnUpdateString, grpc_tls_pem_private_key, zend_skywalking_globals, skywalking_globals)
 	STD_PHP_INI_ENTRY("skywalking.grpc_tls_pem_cert_chain", "", PHP_INI_ALL, OnUpdateString, grpc_tls_pem_cert_chain, zend_skywalking_globals, skywalking_globals)
 
-	STD_PHP_INI_ENTRY("skywalking.log_enable", "0", PHP_INI_ALL, OnUpdateBool, log_enable, zend_skywalking_globals, skywalking_globals)
+	STD_PHP_INI_BOOLEAN("skywalking.log_enable", "0", PHP_INI_ALL, OnUpdateBool, log_enable, zend_skywalking_globals, skywalking_globals)
 	STD_PHP_INI_ENTRY("skywalking.log_path", "/tmp/skywalking-php.log", PHP_INI_ALL, OnUpdateString, log_path, zend_skywalking_globals, skywalking_globals)
 
-    STD_PHP_INI_ENTRY("skywalking.error_handler_enable", "0", PHP_INI_ALL, OnUpdateBool, error_handler_enable, zend_skywalking_globals, skywalking_globals)
+    STD_PHP_INI_BOOLEAN("skywalking.error_handler_enable", "0", PHP_INI_ALL, OnUpdateBool, error_handler_enable, zend_skywalking_globals, skywalking_globals)
+
+    STD_PHP_INI_ENTRY("skywalking.mq_max_message_length", "20480", PHP_INI_ALL, OnUpdateLong, mq_max_message_length, zend_skywalking_globals, skywalking_globals)
 
 PHP_INI_END()
 
@@ -71,6 +72,9 @@ static void php_skywalking_init_globals(zend_skywalking_globals *skywalking_glob
 
     // php error log
     skywalking_globals->error_handler_enable = 0;
+
+    // message queue
+    skywalking_globals->mq_max_message_length = 0;
 }
 
 PHP_FUNCTION (skywalking_trace_id) {
@@ -162,7 +166,6 @@ PHP_MSHUTDOWN_FUNCTION (skywalking) {
 
 PHP_RINIT_FUNCTION(skywalking)
 {
-
 #if defined(COMPILE_DL_SKYWALKING) && defined(ZTS)
 	ZEND_TSRMLS_CACHE_UPDATE();
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -30,7 +30,6 @@ struct service_info {
     char service_instance[0x400];
 
     boost::interprocess::message_queue *mq;
-    int mq_msg_size = 20480;
 };
 
 #endif //SKYWALKING_COMMON_H

--- a/src/sky_log.cc
+++ b/src/sky_log.cc
@@ -1,0 +1,18 @@
+#include <string>
+#include <sstream>
+#include <ostream>
+#include <iostream>
+#include <fstream>
+#include "php_skywalking.h"
+
+static std::ofstream log_fs;
+
+void sky_log(std::string log) {
+  if (SKYWALKING_G(log_enable) && !log_fs.is_open()) {
+      log_fs.open(SKYWALKING_G(log_path), std::ios::app);
+  }
+  
+  if (log_fs.is_open()) {
+    log_fs << log << std::endl;
+  }
+}

--- a/src/sky_log.h
+++ b/src/sky_log.h
@@ -1,0 +1,8 @@
+#include <string>
+
+#ifndef SKYWALKING_SKY_LOG_H
+#define SKYWALKING_SKY_LOG_H
+
+void sky_log(std::string log);
+
+#endif

--- a/src/sky_plugin_redis.h
+++ b/src/sky_plugin_redis.h
@@ -32,6 +32,16 @@ std::string sky_plugin_redis_peer(zend_execute_data *execute_data);
 
 std::string sky_plugin_redis_key_cmd(zend_execute_data *execute_data, std::string cmd);
 
+std::string sky_plugin_redis_set_cmd(zend_execute_data *execute_data, std::string cmd);
+
+std::string sky_plugin_redis_setex_cmd(zend_execute_data *execute_data, std::string cmd);
+
+std::string sky_plugin_redis_multi_key_cmd(zend_execute_data *execute_data, std::string cmd);
+
+std::string sky_plugin_redis_uncertain_keys_cmd(zend_execute_data *execute_data, std::string cmd);
+
+std::string sky_plugin_redis_key_ttl_cmd(zend_execute_data *execute_data, std::string cmd);
+
 std::string sky_plugin_redis_bit_count_cmd(zend_execute_data *execute_data, std::string cmd);
 
 std::string sky_plugin_redis_key_value_cmd(zend_execute_data *execute_data, std::string cmd);


### PR DESCRIPTION
* bostin.wang: 新增配置参数mq_max_message_length(默认2048); 支持redis扩展的set/setex命令

* add e2e cases: redis set/setex

* 添加redis的mget/getmultiple/eval/del/delete/unlink/exists/ping/pipeline/multi/discard/exec/expire/pexpire/expireat/pexpireat/settimeout命令支持